### PR TITLE
fix: prevent duplicate builds for PR branches

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,8 +4,6 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
-    branches:
-      - '**'
     branches-ignore:
       - "main"
       - "gh-pages"
@@ -13,7 +11,6 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/pull/')
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node, Yarn, and Cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,16 +1,20 @@
 name: Build Astro site
 
 on:
-  pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
   push:
     branches-ignore:
       - "main"
       - "gh-pages"
+      - 'dependabot/**' #avoid duplicates: only run the PR, not the push
+    tags-ignore:
+      - 'v*' #avoid rerun existing commit on release
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
 
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node, Yarn, and Cache
@@ -23,6 +27,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     needs: lint
+    if: (github.event_name != 'pull_request' && ! github.event.pull_request.head.repo.fork) || (github.event_name == 'pull_request' && (github.event.pull_request.head.repo.fork || startsWith(github.head_ref, 'dependabot/')))
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node, Yarn, and Cache

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,8 +6,6 @@ on:
       - "main"
       - "gh-pages"
       - 'dependabot/**' #avoid duplicates: only run the PR, not the push
-    tags-ignore:
-      - 'v*' #avoid rerun existing commit on release
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
 

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
   push:
+    branches:
+      - '**'
     branches-ignore:
       - "main"
       - "gh-pages"
@@ -11,6 +13,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || !startsWith(github.ref, 'refs/pull/')
     steps:
       - uses: actions/checkout@v5
       - name: Setup Node, Yarn, and Cache

--- a/.gitignore
+++ b/.gitignore
@@ -257,3 +257,6 @@ $RECYCLE.BIN/
 # .pnp.*
 
 # End of https://www.toptal.com/developers/gitignore/api/yarn,node,visualstudiocode,macos,linux,windows,astro
+
+# Claude Code local settings
+.claude/settings.local.json


### PR DESCRIPTION
Add condition to prevent GitHub Actions from running both push and pull_request triggers for the same commit on PR branches, eliminating duplicate builds while preserving builds for branch pushes and PR automations.

🤖 Generated with [Claude Code](https://claude.ai/code)