### PR TITLE
chore(deps): group dependabot updates by ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(deps)"
     open-pull-requests-limit: 10
@@ -16,6 +20,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      all:
+        patterns:
+          - "*"
     commit-message:
       prefix: "chore(actions)"
     open-pull-requests-limit: 10


### PR DESCRIPTION
Updates the Dependabot configuration to group all dependency
updates for the 'bun' and 'github-actions' ecosystems into a
single pull request each, using a wildcard pattern matching
all packages. This reduces PR noise and keeps dependencies
manageable.

---
*PR created automatically by Jules for task [13810125927037871908](https://jules.google.com/task/13810125927037871908) started by @mkobit*