### PR TITLE
chore: update mise config to enforce lockfile and retries

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,6 @@
 [tools]
 bun = "1.3.11"
+
+[settings]
+http_retries = 5
+lockfile = true


### PR DESCRIPTION
This PR updates `mise.toml` to:
1. Enable `lockfile = true` to ensure the `mise.lock` file is strictly used when managing tools, enforcing pinned versions and checksums.
2. Set `http_retries = 5` to improve the reliability of tool fetching.

---
*PR created automatically by Jules for task [16303146541718903297](https://jules.google.com/task/16303146541718903297) started by @mkobit*