### PR TITLE
fix(mdx): import Latex component in tech-demo

### DIFF
--- a/src/content/blog/2024-05-20_tech-demo/index.mdx
+++ b/src/content/blog/2024-05-20_tech-demo/index.mdx
@@ -5,7 +5,7 @@ description: "Documentation and usage examples for available components and Mark
 labels: ["demo", "components"]
 ---
 
-{/* eslint-disable no-unused-vars */}
+
 import { Callout } from '../../../components/ui/callout';
 import EChart from '../../../components/EChart.astro';
 import IconBlock from '../../../components/IconBlock';
@@ -26,6 +26,7 @@ Cloud,
 Code
 } from 'lucide-react';
 import { DataTable } from '../../../components/ui/table';
+import Latex from '../../../components/Latex.astro';
 
 export const users = [
   { id: 1, name: "John Doe", role: "Admin", status: "Active" },


### PR DESCRIPTION
Fixes build failure caused by missing `Latex` component import and removes unused eslint-disable directive.

---
*PR created automatically by Jules for task [9066550886446422445](https://jules.google.com/task/9066550886446422445) started by @mkobit*